### PR TITLE
[TECH] Consolider les tests unitaires et extraire un service mail (PIX-22777)

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -2,11 +2,9 @@ import { defineAction } from "astro:actions";
 import { z } from "astro:schema";
 import { FriendlyCaptchaClient } from "@friendlycaptcha/server-sdk";
 import "dotenv/config";
-import nodemailer from "nodemailer";
-import type SMTPTransport from "nodemailer/lib/smtp-transport";
-import { processBase64Attachment } from "../services/attachments.service.ts";
 import { getConfigParam } from "../services/config.service.ts";
 import { createConversation } from "../services/freescout.service.ts";
+import { sendFormEmail } from "../services/mail.service.ts";
 
 export const server = {
 	answer: defineAction({
@@ -67,53 +65,7 @@ export const server = {
 			}
 
 			if (sendByEmail && emailRecipientAddress) {
-				const sender = `${formResult.customer_firstname} ${formResult.customer_lastname} <forms@pix.digital>`;
-				const subject = formResult.subject;
-
-				const smtpOptions: SMTPTransport.Options = {
-					host: getConfigParam("SMTP_HOST"),
-					port: Number(getConfigParam("SMTP_PORT")),
-					secure: getConfigParam("SMTP_SECURE") === "true",
-					auth: {
-						user: getConfigParam("SMTP_USER"),
-						pass: getConfigParam("SMTP_PASS"),
-					},
-				};
-
-				const transporter = nodemailer.createTransport(smtpOptions);
-
-				const message = Object.entries(formResult)
-					.map(([key, value]) => {
-						if (key !== "attachments") {
-							return `<strong>${key}</strong><br> ${value}`;
-						}
-						return null;
-					})
-					.join("<br><br>");
-
-				const email = {
-					from: sender,
-					replyTo: formResult.customer_email,
-					to: emailRecipientAddress,
-					subject,
-					html: message.replace(/\n/g, "<br>"),
-					attachments: [],
-				};
-
-				if (formResult.attachments && formResult.attachments.length > 0) {
-					email.attachments = formResult.attachments.map((attachment: any) => {
-						return {
-							filename: attachment.name,
-							content: processBase64Attachment(attachment.content),
-							contentType: attachment.type,
-							encoding: "base64",
-						};
-					});
-				}
-
-				const info = await transporter.sendMail(email);
-
-				console.log("Message sent:", info.messageId);
+				await sendFormEmail(formResult, emailRecipientAddress);
 			}
 
 			console.log(`Form submitted`);

--- a/src/quill.ts
+++ b/src/quill.ts
@@ -56,7 +56,7 @@ export default function initQuill(
 			updateValueHandler();
 		},
 		willUnmount: (_: Question, el: HTMLElement) => {
-			el.previousSibling && el.previousSibling.remove();
+			el.previousSibling?.remove();
 			el.innerHTML = "";
 		},
 	};

--- a/src/services/freescout.service.ts
+++ b/src/services/freescout.service.ts
@@ -23,12 +23,6 @@ type FreescoutAttachment = {
 	data: string;
 };
 
-const getHeaders = () => ({
-	"X-FreeScout-API-Key": getConfigParam("FREESCOUT_API_KEY"),
-	"Content-Type": "application/json",
-	Accept: "application/json",
-});
-
 export async function createConversation(
 	formResult: FormResult,
 	freescoutMailboxId: number,
@@ -46,7 +40,7 @@ export async function createConversation(
 			firstName: formResult.customer_firstname,
 			lastName: formResult.customer_lastname,
 		},
-		customFields: extractCustomFields(formResult, "custom_field_"),
+		customFields: _extractCustomFields(formResult, "custom_field_"),
 		threads: [
 			{
 				text: formResult.message,
@@ -54,14 +48,14 @@ export async function createConversation(
 				customer: {
 					email: formResult.customer_email,
 				},
-				attachments: formResult.attachments?.map(formatAttachment),
+				attachments: formResult.attachments?.map(_formatAttachment),
 			},
 		],
 	};
 
 	const response = await fetch(url, {
 		method: "POST",
-		headers: getHeaders(),
+		headers: _getHeaders(),
 		body: JSON.stringify(body),
 	});
 
@@ -73,7 +67,7 @@ export async function createConversation(
 	console.log(`Conversation #${result.id} created`);
 	if (!result) return;
 	const { id: customerId, lastName, firstName } = result.customer;
-	await updateCustomerAndCustomerFields(
+	await _updateCustomerAndCustomerFields(
 		customerId,
 		firstName,
 		lastName,
@@ -81,21 +75,40 @@ export async function createConversation(
 	);
 }
 
-async function updateCustomerAndCustomerFields(
-	customerId: number,
-	firstName: string,
-	lastName: string,
+function _extractCustomFields(
 	formResult: FormResult,
-) {
-	if (!customerId) {
-		console.log("pas de customer à update");
-		return;
-	}
-	await updateCustomer(customerId, firstName, lastName, formResult);
-	await updateCustomerFields(customerId, formResult);
+	customFieldPrefix: string,
+): { id: number; value: string | number | Attachement[] }[] {
+	return Object.entries(formResult)
+		.map(([key, value]) => {
+			if (key.startsWith(customFieldPrefix)) {
+				const customerFieldId = Number(key.replace(customFieldPrefix, ""));
+				return { id: customerFieldId, value };
+			}
+			return null;
+		})
+		.filter((field) => field !== null);
 }
 
-async function updateCustomer(
+function _formatAttachment({
+	name,
+	type,
+	content,
+}: Attachement): FreescoutAttachment {
+	return {
+		fileName: name,
+		mimeType: type,
+		data: processBase64Attachment(content),
+	};
+}
+
+const _getHeaders = () => ({
+	"X-FreeScout-API-Key": getConfigParam("FREESCOUT_API_KEY"),
+	"Content-Type": "application/json",
+	Accept: "application/json",
+});
+
+async function _updateCustomer(
 	customerId: number,
 	firstName: string,
 	lastName: string,
@@ -118,16 +131,30 @@ async function updateCustomer(
 
 	await fetch(updateUrl, {
 		method: "PUT",
-		headers: getHeaders(),
+		headers: _getHeaders(),
 		body,
 	});
 }
 
-async function updateCustomerFields(
+async function _updateCustomerAndCustomerFields(
+	customerId: number,
+	firstName: string,
+	lastName: string,
+	formResult: FormResult,
+) {
+	if (!customerId) {
+		console.log("pas de customer à update");
+		return;
+	}
+	await _updateCustomer(customerId, firstName, lastName, formResult);
+	await _updateCustomerFields(customerId, formResult);
+}
+
+async function _updateCustomerFields(
 	customerId: number,
 	formResult: FormResult,
 ) {
-	const customerFields = extractCustomFields(formResult, "customer_field_");
+	const customerFields = _extractCustomFields(formResult, "customer_field_");
 
 	if (!customerFields.length) {
 		console.log("pas de customerFields à update");
@@ -141,34 +168,7 @@ async function updateCustomerFields(
 
 	await fetch(updateUrl, {
 		method: "PUT",
-		headers: getHeaders(),
+		headers: _getHeaders(),
 		body,
 	});
-}
-
-export function formatAttachment({
-	name,
-	type,
-	content,
-}: Attachement): FreescoutAttachment {
-	return {
-		fileName: name,
-		mimeType: type,
-		data: processBase64Attachment(content),
-	};
-}
-
-export function extractCustomFields(
-	formResult: FormResult,
-	customFieldPrefix: string,
-): { id: number; value: string | number | Attachement[] }[] {
-	return Object.entries(formResult)
-		.map(([key, value]) => {
-			if (key.startsWith(customFieldPrefix)) {
-				const customerFieldId = Number(key.replace(customFieldPrefix, ""));
-				return { id: customerFieldId, value };
-			}
-			return null;
-		})
-		.filter((field) => field !== null);
 }

--- a/src/services/freescout.service.ts
+++ b/src/services/freescout.service.ts
@@ -66,13 +66,17 @@ export async function createConversation(
 	}
 
 	console.log(`Conversation #${result.id} created`);
-	const { id: customerId, lastName, firstName } = result.customer;
-	await _updateCustomerAndCustomerFields(
-		customerId,
-		firstName,
-		lastName,
-		formResult,
-	);
+	const { id: customerId, firstName, lastName } = result.customer;
+	if (!customerId) return;
+
+	if (_hasNameChanged(firstName, lastName, formResult)) {
+		await _updateCustomer(customerId, formResult);
+	}
+
+	const customerFields = _extractCustomFields(formResult, "customer_field_");
+	if (_hasCustomerFields(customerFields)) {
+		await _updateCustomerFields(customerId, customerFields);
+	}
 }
 
 function _extractCustomFields(
@@ -107,67 +111,47 @@ function _getHeaders() {
 	};
 }
 
-async function _updateCustomer(
-	customerId: number,
+function _hasCustomerFields(
+	customerFields: { id: number; value: string | number | Attachment[] }[],
+): boolean {
+	return customerFields.length > 0;
+}
+
+function _hasNameChanged(
 	firstName: string,
 	lastName: string,
 	formResult: FormResult,
-) {
-	if (
-		firstName === formResult.customer_firstname &&
-		lastName === formResult.customer_lastname
-	) {
-		return;
-	}
+): boolean {
+	return (
+		firstName !== formResult.customer_firstname ||
+		lastName !== formResult.customer_lastname
+	);
+}
+
+async function _updateCustomer(customerId: number, formResult: FormResult) {
 	const updateUrl = new URL(
 		`${getConfigParam("FREESCOUT_API_URL")}/api/customers/${customerId}`,
 	);
-
-	const body = JSON.stringify({
-		firstName: formResult.customer_firstname,
-		lastName: formResult.customer_lastname,
-	});
-
 	await fetch(updateUrl, {
 		method: "PUT",
 		headers: _getHeaders(),
-		body,
+		body: JSON.stringify({
+			firstName: formResult.customer_firstname,
+			lastName: formResult.customer_lastname,
+		}),
 	});
-}
-
-async function _updateCustomerAndCustomerFields(
-	customerId: number,
-	firstName: string,
-	lastName: string,
-	formResult: FormResult,
-) {
-	if (!customerId) {
-		console.log("pas de customer à update");
-		return;
-	}
-	await _updateCustomer(customerId, firstName, lastName, formResult);
-	await _updateCustomerFields(customerId, formResult);
 }
 
 async function _updateCustomerFields(
 	customerId: number,
-	formResult: FormResult,
+	customerFields: { id: number; value: string | number | Attachment[] }[],
 ) {
-	const customerFields = _extractCustomFields(formResult, "customer_field_");
-
-	if (!customerFields.length) {
-		console.log("pas de customerFields à update");
-		return;
-	}
-
 	const updateUrl = new URL(
 		`${getConfigParam("FREESCOUT_API_URL")}/api/customers/${customerId}/customer_fields`,
 	);
-	const body = JSON.stringify({ customerFields });
-
 	await fetch(updateUrl, {
 		method: "PUT",
 		headers: _getHeaders(),
-		body,
+		body: JSON.stringify({ customerFields }),
 	});
 }

--- a/src/services/freescout.service.ts
+++ b/src/services/freescout.service.ts
@@ -1,7 +1,7 @@
 import { processBase64Attachment } from "./attachments.service.ts";
 import { getConfigParam } from "./config.service.ts";
 
-type Attachement = {
+type Attachment = {
 	name: string;
 	type: string;
 	content: string; // base64 encoded content
@@ -13,8 +13,8 @@ type FormResult = {
 	customer_lastname: string;
 	subject: string;
 	message: string;
-	attachments: Attachement[];
-	[key: string]: string | number | Attachement[];
+	attachments: Attachment[];
+	[key: string]: string | number | Attachment[];
 };
 
 type FreescoutAttachment = {
@@ -60,12 +60,12 @@ export async function createConversation(
 	});
 
 	const result = await response.json();
+	if (!result) return;
 	if (result.message === "Error occurred") {
 		throw new Error(JSON.stringify(result));
 	}
 
 	console.log(`Conversation #${result.id} created`);
-	if (!result) return;
 	const { id: customerId, lastName, firstName } = result.customer;
 	await _updateCustomerAndCustomerFields(
 		customerId,
@@ -78,23 +78,20 @@ export async function createConversation(
 function _extractCustomFields(
 	formResult: FormResult,
 	customFieldPrefix: string,
-): { id: number; value: string | number | Attachement[] }[] {
+): { id: number; value: string | number | Attachment[] }[] {
 	return Object.entries(formResult)
-		.map(([key, value]) => {
-			if (key.startsWith(customFieldPrefix)) {
-				const customerFieldId = Number(key.replace(customFieldPrefix, ""));
-				return { id: customerFieldId, value };
-			}
-			return null;
-		})
-		.filter((field) => field !== null);
+		.filter(([key]) => key.startsWith(customFieldPrefix))
+		.map(([key, value]) => ({
+			id: Number(key.replace(customFieldPrefix, "")),
+			value,
+		}));
 }
 
 function _formatAttachment({
 	name,
 	type,
 	content,
-}: Attachement): FreescoutAttachment {
+}: Attachment): FreescoutAttachment {
 	return {
 		fileName: name,
 		mimeType: type,
@@ -102,11 +99,13 @@ function _formatAttachment({
 	};
 }
 
-const _getHeaders = () => ({
-	"X-FreeScout-API-Key": getConfigParam("FREESCOUT_API_KEY"),
-	"Content-Type": "application/json",
-	Accept: "application/json",
-});
+function _getHeaders() {
+	return {
+		"X-FreeScout-API-Key": getConfigParam("FREESCOUT_API_KEY"),
+		"Content-Type": "application/json",
+		Accept: "application/json",
+	};
+}
 
 async function _updateCustomer(
 	customerId: number,

--- a/src/services/mail.service.ts
+++ b/src/services/mail.service.ts
@@ -1,0 +1,69 @@
+import nodemailer from "nodemailer";
+import type SMTPTransport from "nodemailer/lib/smtp-transport";
+import { processBase64Attachment } from "./attachments.service.ts";
+import { getConfigParam } from "./config.service.ts";
+
+type MailAttachment = {
+	name: string;
+	type: string;
+	content: string;
+};
+
+type FormResult = {
+	customer_firstname: string;
+	customer_lastname: string;
+	customer_email: string;
+	subject: string;
+	attachments?: MailAttachment[];
+	[key: string]: unknown;
+};
+
+export function buildEmailBody(formResult: FormResult): string {
+	return Object.entries(formResult)
+		.filter(([key]) => key !== "attachments")
+		.map(([key, value]) => `<strong>${key}</strong><br> ${value}`)
+		.join("<br><br>");
+}
+
+export function formatMailAttachment(
+	attachment: MailAttachment,
+): nodemailer.Attachment {
+	return {
+		filename: attachment.name,
+		content: processBase64Attachment(attachment.content),
+		contentType: attachment.type,
+		encoding: "base64",
+	};
+}
+
+async function sendEmail(options: nodemailer.SendMailOptions): Promise<void> {
+	const smtpOptions: SMTPTransport.Options = {
+		host: getConfigParam("SMTP_HOST"),
+		port: Number(getConfigParam("SMTP_PORT")),
+		secure: getConfigParam("SMTP_SECURE") === "true",
+		auth: {
+			user: getConfigParam("SMTP_USER"),
+			pass: getConfigParam("SMTP_PASS"),
+		},
+	};
+	const transporter = nodemailer.createTransport(smtpOptions);
+	const info = await transporter.sendMail(options);
+	console.log("Message sent:", info.messageId);
+}
+
+export async function sendFormEmail(
+	formResult: FormResult,
+	recipientAddress: string,
+): Promise<void> {
+	const sender = `${formResult.customer_firstname} ${formResult.customer_lastname} <forms@pix.digital>`;
+	const body = buildEmailBody(formResult);
+
+	await sendEmail({
+		from: sender,
+		replyTo: formResult.customer_email as string,
+		to: recipientAddress,
+		subject: formResult.subject,
+		html: body.replace(/\n/g, "<br>"),
+		attachments: formResult.attachments?.map(formatMailAttachment) ?? [],
+	});
+}

--- a/src/services/mail.service.ts
+++ b/src/services/mail.service.ts
@@ -1,4 +1,5 @@
 import nodemailer from "nodemailer";
+import type Mail from "nodemailer/lib/mailer";
 import type SMTPTransport from "nodemailer/lib/smtp-transport";
 import { processBase64Attachment } from "./attachments.service.ts";
 import { getConfigParam } from "./config.service.ts";
@@ -18,16 +19,31 @@ type FormResult = {
 	[key: string]: unknown;
 };
 
-export function buildEmailBody(formResult: FormResult): string {
+export async function sendFormEmail(
+	formResult: FormResult,
+	recipientAddress: string,
+): Promise<void> {
+	const sender = `${formResult.customer_firstname} ${formResult.customer_lastname} <forms@pix.digital>`;
+	const body = _buildEmailBody(formResult);
+
+	await _sendEmail({
+		from: sender,
+		replyTo: formResult.customer_email as string,
+		to: recipientAddress,
+		subject: formResult.subject,
+		html: body.replace(/\n/g, "<br>"),
+		attachments: formResult.attachments?.map(_formatMailAttachment) ?? [],
+	});
+}
+
+function _buildEmailBody(formResult: FormResult): string {
 	return Object.entries(formResult)
 		.filter(([key]) => key !== "attachments")
 		.map(([key, value]) => `<strong>${key}</strong><br> ${value}`)
 		.join("<br><br>");
 }
 
-export function formatMailAttachment(
-	attachment: MailAttachment,
-): nodemailer.Attachment {
+function _formatMailAttachment(attachment: MailAttachment): Mail.Attachment {
 	return {
 		filename: attachment.name,
 		content: processBase64Attachment(attachment.content),
@@ -36,7 +52,7 @@ export function formatMailAttachment(
 	};
 }
 
-async function sendEmail(options: nodemailer.SendMailOptions): Promise<void> {
+async function _sendEmail(options: nodemailer.SendMailOptions): Promise<void> {
 	const smtpOptions: SMTPTransport.Options = {
 		host: getConfigParam("SMTP_HOST"),
 		port: Number(getConfigParam("SMTP_PORT")),
@@ -49,21 +65,4 @@ async function sendEmail(options: nodemailer.SendMailOptions): Promise<void> {
 	const transporter = nodemailer.createTransport(smtpOptions);
 	const info = await transporter.sendMail(options);
 	console.log("Message sent:", info.messageId);
-}
-
-export async function sendFormEmail(
-	formResult: FormResult,
-	recipientAddress: string,
-): Promise<void> {
-	const sender = `${formResult.customer_firstname} ${formResult.customer_lastname} <forms@pix.digital>`;
-	const body = buildEmailBody(formResult);
-
-	await sendEmail({
-		from: sender,
-		replyTo: formResult.customer_email as string,
-		to: recipientAddress,
-		subject: formResult.subject,
-		html: body.replace(/\n/g, "<br>"),
-		attachments: formResult.attachments?.map(formatMailAttachment) ?? [],
-	});
 }

--- a/src/services/mail.service.ts
+++ b/src/services/mail.service.ts
@@ -28,7 +28,7 @@ export async function sendFormEmail(
 
 	await _sendEmail({
 		from: sender,
-		replyTo: formResult.customer_email as string,
+		replyTo: formResult.customer_email,
 		to: recipientAddress,
 		subject: formResult.subject,
 		html: body.replace(/\n/g, "<br>"),

--- a/tests/unit/services/attachments.service.test.ts
+++ b/tests/unit/services/attachments.service.test.ts
@@ -10,7 +10,7 @@ describe("Unit | Services | Attachments", () => {
 			const result = processBase64Attachment(fileContent);
 
 			// then
-			expect(result).to.equal("ABC123");
+			expect(result).toBe("ABC123");
 		});
 	});
 });

--- a/tests/unit/services/config.service.test.ts
+++ b/tests/unit/services/config.service.test.ts
@@ -1,10 +1,6 @@
-import { vi } from "vitest";
 import { getConfigParam } from "../../../src/services/config.service";
 
 describe("Unit | Services | Config", () => {
-	afterEach(() => {
-		vi.unstubAllEnvs();
-	});
 
 	describe("#getConfigParam", () => {
 		describe("When env variable is defined", () => {

--- a/tests/unit/services/config.service.test.ts
+++ b/tests/unit/services/config.service.test.ts
@@ -1,7 +1,6 @@
 import { getConfigParam } from "../../../src/services/config.service";
 
 describe("Unit | Services | Config", () => {
-
 	describe("#getConfigParam", () => {
 		describe("When env variable is defined", () => {
 			test("it should return its value", () => {

--- a/tests/unit/services/freescout.service.test.ts
+++ b/tests/unit/services/freescout.service.test.ts
@@ -1,8 +1,4 @@
-import {
-	createConversation,
-	extractCustomFields,
-	formatAttachment,
-} from "../../../src/services/freescout.service";
+import { createConversation } from "../../../src/services/freescout.service";
 
 const defaultFormResult = {
 	customer_email: "john@example.com",
@@ -25,108 +21,12 @@ function mockFetch(customer = { id: 1, firstName: "John", lastName: "Doe" }) {
 }
 
 describe("Unit | Services | Freescout", () => {
-	describe("#extractCustomFields", () => {
-		describe("When properties are matching `custom_field_` prefix", () => {
-			test("it should return an array of custom fields with their ids and values", () => {
-				// given
-				const form = {
-					customer_email: "robloche@example.net",
-					customer_firstname: "Rob",
-					customer_lastname: "Lochon",
-					subject: "Sujet",
-					message: "My message",
-					attachments: [],
-					custom_field_123: "Value for 123",
-					custom_field_456: "Value for 456",
-				};
-
-				// when
-				const result = extractCustomFields(form, "custom_field_");
-
-				// then
-				expect(result).toEqual([
-					{ id: 123, value: "Value for 123" },
-					{ id: 456, value: "Value for 456" },
-				]);
-			});
-		});
-
-		describe("When passing `customer_field` prefix", () => {
-			test("it should return an array of `customer fields` with their ids and values", () => {
-				// given
-				const form = {
-					customer_email: "robloche@example.net",
-					customer_firstname: "Rob",
-					customer_lastname: "Lochon",
-					subject: "Sujet",
-					message: "My message",
-					attachments: [],
-					customer_field_1: "Value for customer field 1",
-					customer_field_2: "Value for customer field 2",
-				};
-
-				// when
-				const result = extractCustomFields(form, "customer_field_");
-
-				// then
-				expect(result).toEqual([
-					{ id: 1, value: "Value for customer field 1" },
-					{ id: 2, value: "Value for customer field 2" },
-				]);
-			});
-		});
-
-		describe("When no custom fields are matching the prefix", () => {
-			test("it should return an empty array", () => {
-				// given
-				const form = {
-					customer_email: "robloche@example.net",
-					customer_firstname: "Rob",
-					customer_lastname: "Lochon",
-					subject: "Sujet",
-					message: "My message",
-					attachments: [],
-					custom_field_1: "Value for 123",
-					custom_field_2: "Value for 456",
-				};
-
-				// when
-				const result = extractCustomFields(form, "foo");
-
-				// then
-				expect(result).toEqual([]);
-			});
-		});
-	});
-
-	describe("#formatAttachment", () => {
-		test("it should return an object matching required interface for Freescout", () => {
-			// given
-			const attachment = {
-				name: "document.pdf",
-				type: "application/pdf",
-				content: "data:application/pdf;base64,ABC123",
-			};
-
-			// when
-			const result = formatAttachment(attachment);
-
-			// then
-			expect(result).toEqual({
-				fileName: "document.pdf",
-				mimeType: "application/pdf",
-				data: "ABC123",
-			});
-		});
-	});
-
 	describe("#createConversation", () => {
 		beforeEach(() => {
 			vi.stubEnv("FREESCOUT_API_KEY", "test-api-key");
 			vi.stubEnv("FREESCOUT_API_URL", "https://freescout.test");
 			vi.spyOn(console, "log").mockImplementation(() => {});
 		});
-
 
 		describe("When the API call succeeds", () => {
 			test("it should POST the conversation with the correct body and log its id", async () => {

--- a/tests/unit/services/freescout.service.test.ts
+++ b/tests/unit/services/freescout.service.test.ts
@@ -1,7 +1,28 @@
 import {
+	createConversation,
 	extractCustomFields,
 	formatAttachment,
 } from "../../../src/services/freescout.service";
+
+const defaultFormResult = {
+	customer_email: "john@example.com",
+	customer_firstname: "John",
+	customer_lastname: "Doe",
+	subject: "Help",
+	message: "I need help",
+	attachments: [],
+};
+
+function mockFetch(customer = { id: 1, firstName: "John", lastName: "Doe" }) {
+	const fetchMock = vi
+		.fn()
+		.mockResolvedValueOnce({
+			json: () => Promise.resolve({ id: 42, customer }),
+		})
+		.mockResolvedValue({ json: () => Promise.resolve({}) });
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
 
 describe("Unit | Services | Freescout", () => {
 	describe("#extractCustomFields", () => {
@@ -95,6 +116,183 @@ describe("Unit | Services | Freescout", () => {
 				fileName: "document.pdf",
 				mimeType: "application/pdf",
 				data: "ABC123",
+			});
+		});
+	});
+
+	describe("#createConversation", () => {
+		beforeEach(() => {
+			vi.stubEnv("FREESCOUT_API_KEY", "test-api-key");
+			vi.stubEnv("FREESCOUT_API_URL", "https://freescout.test");
+			vi.spyOn(console, "log").mockImplementation(() => {});
+		});
+
+
+		describe("When the API call succeeds", () => {
+			test("it should POST the conversation with the correct body and log its id", async () => {
+				// given
+				const fetchMock = mockFetch();
+
+				// when
+				await createConversation(defaultFormResult, 3);
+
+				// then
+				const [postUrl, postOptions] = fetchMock.mock.calls[0];
+				expect(postUrl.href).toContain("/api/conversations");
+				expect(postOptions.method).toBe("POST");
+				expect(JSON.parse(postOptions.body)).toMatchObject({
+					type: "email",
+					mailboxId: 3,
+					subject: "Help",
+					customer: {
+						email: "john@example.com",
+						firstName: "John",
+						lastName: "Doe",
+					},
+				});
+				expect(vi.mocked(console.log)).toHaveBeenCalledWith(
+					"Conversation #42 created",
+				);
+			});
+		});
+
+		describe("When the API returns an error", () => {
+			test("it should throw an error", async () => {
+				// given
+				vi.stubGlobal(
+					"fetch",
+					vi.fn().mockResolvedValue({
+						json: () =>
+							Promise.resolve({
+								message: "Error occurred",
+								errors: ["invalid mailbox"],
+							}),
+					}),
+				);
+
+				// when / then
+				await expect(
+					createConversation(defaultFormResult, 3),
+				).rejects.toThrow();
+			});
+		});
+
+		describe("Regarding customer name update", () => {
+			describe("When both names differ from the returned ones", () => {
+				test("it should call the customer update endpoint with the new names", async () => {
+					// given
+					const fetchMock = mockFetch({
+						id: 7,
+						firstName: "Old",
+						lastName: "Name",
+					});
+
+					// when
+					await createConversation(defaultFormResult, 3);
+
+					// then
+					const putCalls = fetchMock.mock.calls.filter(
+						([url]) =>
+							(url as URL).href.includes("/api/customers/7") &&
+							!(url as URL).href.includes("customer_fields"),
+					);
+					expect(putCalls).toHaveLength(1);
+					expect(putCalls[0][1].method).toBe("PUT");
+					expect(JSON.parse(putCalls[0][1].body)).toEqual({
+						firstName: "John",
+						lastName: "Doe",
+					});
+				});
+			});
+
+			describe("When only one name differs from the returned one", () => {
+				test("it should call the customer update endpoint", async () => {
+					// given
+					const fetchMock = mockFetch({
+						id: 1,
+						firstName: "Old",
+						lastName: "Doe",
+					});
+
+					// when
+					await createConversation(defaultFormResult, 3);
+
+					// then
+					const customerUpdateCalls = fetchMock.mock.calls.filter(
+						([url]) =>
+							(url as URL).href.includes("/api/customers/1") &&
+							!(url as URL).href.includes("customer_fields"),
+					);
+					expect(customerUpdateCalls).toHaveLength(1);
+				});
+			});
+
+			describe("When names match the returned ones", () => {
+				test("it should not call the customer update endpoint", async () => {
+					// given
+					const fetchMock = mockFetch({
+						id: 1,
+						firstName: "John",
+						lastName: "Doe",
+					});
+
+					// when
+					await createConversation(defaultFormResult, 3);
+
+					// then
+					const customerUpdateCalls = fetchMock.mock.calls.filter(
+						([url]) =>
+							(url as URL).href.includes("/api/customers/1") &&
+							!(url as URL).href.includes("customer_fields"),
+					);
+					expect(customerUpdateCalls).toHaveLength(0);
+				});
+			});
+		});
+
+		describe("Regarding customer fields update", () => {
+			describe("When the form has customer fields", () => {
+				test("it should call the customer fields update endpoint", async () => {
+					// given
+					const formResult = {
+						...defaultFormResult,
+						customer_field_5: "important value",
+					};
+					const fetchMock = mockFetch({
+						id: 1,
+						firstName: "John",
+						lastName: "Doe",
+					});
+
+					// when
+					await createConversation(formResult, 3);
+
+					// then
+					const customerFieldsCalls = fetchMock.mock.calls.filter(([url]) =>
+						(url as URL).href.includes("/api/customers/1/customer_fields"),
+					);
+					expect(customerFieldsCalls).toHaveLength(1);
+					expect(customerFieldsCalls[0][1].method).toBe("PUT");
+					expect(JSON.parse(customerFieldsCalls[0][1].body)).toEqual({
+						customerFields: [{ id: 5, value: "important value" }],
+					});
+				});
+			});
+
+			describe("When the form has no customer fields", () => {
+				test("it should not call the customer fields update endpoint", async () => {
+					// given
+					const fetchMock = mockFetch();
+
+					// when
+					await createConversation(defaultFormResult, 3);
+
+					// then
+					const customerFieldsCalls = fetchMock.mock.calls.filter(([url]) =>
+						(url as URL).href.includes("/api/customers/1/customer_fields"),
+					);
+					expect(customerFieldsCalls).toHaveLength(0);
+				});
 			});
 		});
 	});

--- a/tests/unit/services/mail.service.test.ts
+++ b/tests/unit/services/mail.service.test.ts
@@ -1,8 +1,4 @@
-import {
-	buildEmailBody,
-	formatMailAttachment,
-	sendFormEmail,
-} from "../../../src/services/mail.service.ts";
+import { sendFormEmail } from "../../../src/services/mail.service.ts";
 
 const sendMailMock = vi
 	.fn()
@@ -23,50 +19,6 @@ const defaultFormResult = {
 };
 
 describe("Unit | Services | Mail", () => {
-	describe("#buildEmailBody", () => {
-		test("it should format form fields as HTML excluding attachments key", () => {
-			// given
-			const formResult = {
-				customer_firstname: "John",
-				customer_lastname: "Doe",
-				customer_email: "john@example.com",
-				subject: "Help",
-				message: "I need help",
-				attachments: [],
-			};
-
-			// when
-			const result = buildEmailBody(formResult);
-
-			// then
-			expect(result).toContain("<strong>customer_firstname</strong><br> John");
-			expect(result).toContain("<strong>message</strong><br> I need help");
-			expect(result).not.toContain("attachments");
-		});
-	});
-
-	describe("#formatMailAttachment", () => {
-		test("it should return a nodemailer attachment from a form attachment", () => {
-			// given
-			const attachment = {
-				name: "document.pdf",
-				type: "application/pdf",
-				content: "data:application/pdf;base64,JVBERi0x",
-			};
-
-			// when
-			const result = formatMailAttachment(attachment);
-
-			// then
-			expect(result).toEqual({
-				filename: "document.pdf",
-				contentType: "application/pdf",
-				encoding: "base64",
-				content: "JVBERi0x",
-			});
-		});
-	});
-
 	describe("#sendFormEmail", () => {
 		beforeEach(() => {
 			sendMailMock.mockClear();

--- a/tests/unit/services/mail.service.test.ts
+++ b/tests/unit/services/mail.service.test.ts
@@ -1,0 +1,127 @@
+import {
+	buildEmailBody,
+	formatMailAttachment,
+	sendFormEmail,
+} from "../../../src/services/mail.service.ts";
+
+const sendMailMock = vi
+	.fn()
+	.mockResolvedValue({ messageId: "test-message-id" });
+vi.mock("nodemailer", () => ({
+	default: {
+		createTransport: vi.fn(() => ({ sendMail: sendMailMock })),
+	},
+}));
+
+const defaultFormResult = {
+	customer_firstname: "John",
+	customer_lastname: "Doe",
+	customer_email: "john@example.com",
+	subject: "Demande d'aide",
+	message: "Bonjour",
+	attachments: [],
+};
+
+describe("Unit | Services | Mail", () => {
+	describe("#buildEmailBody", () => {
+		test("it should format form fields as HTML excluding attachments key", () => {
+			// given
+			const formResult = {
+				customer_firstname: "John",
+				customer_lastname: "Doe",
+				customer_email: "john@example.com",
+				subject: "Help",
+				message: "I need help",
+				attachments: [],
+			};
+
+			// when
+			const result = buildEmailBody(formResult);
+
+			// then
+			expect(result).toContain("<strong>customer_firstname</strong><br> John");
+			expect(result).toContain("<strong>message</strong><br> I need help");
+			expect(result).not.toContain("attachments");
+		});
+	});
+
+	describe("#formatMailAttachment", () => {
+		test("it should return a nodemailer attachment from a form attachment", () => {
+			// given
+			const attachment = {
+				name: "document.pdf",
+				type: "application/pdf",
+				content: "data:application/pdf;base64,JVBERi0x",
+			};
+
+			// when
+			const result = formatMailAttachment(attachment);
+
+			// then
+			expect(result).toEqual({
+				filename: "document.pdf",
+				contentType: "application/pdf",
+				encoding: "base64",
+				content: "JVBERi0x",
+			});
+		});
+	});
+
+	describe("#sendFormEmail", () => {
+		beforeEach(() => {
+			sendMailMock.mockClear();
+			vi.stubEnv("SMTP_HOST", "localhost");
+			vi.stubEnv("SMTP_PORT", "1025");
+			vi.stubEnv("SMTP_SECURE", "false");
+			vi.stubEnv("SMTP_USER", "user");
+			vi.stubEnv("SMTP_PASS", "pass");
+		});
+
+		describe("When sending an email without attachments", () => {
+			test("it should call sendMail with the correct recipient, subject, sender, replyTo and body", async () => {
+				// when
+				await sendFormEmail(defaultFormResult, "contact@example.com");
+
+				// then
+				expect(sendMailMock).toHaveBeenCalledOnce();
+				const emailArg = sendMailMock.mock.calls[0][0];
+				expect(emailArg.to).toBe("contact@example.com");
+				expect(emailArg.subject).toBe("Demande d'aide");
+				expect(emailArg.from).toBe("John Doe <forms@pix.digital>");
+				expect(emailArg.replyTo).toBe("john@example.com");
+				expect(emailArg.attachments).toEqual([]);
+				expect(emailArg.html).toContain("<strong>message</strong><br> Bonjour");
+				expect(emailArg.html).not.toContain("attachments");
+			});
+		});
+
+		describe("When sending an email with attachments", () => {
+			test("it should include formatted attachments", async () => {
+				// given
+				const formResult = {
+					...defaultFormResult,
+					attachments: [
+						{
+							name: "document.pdf",
+							type: "application/pdf",
+							content: "data:application/pdf;base64,JVBERi0x",
+						},
+					],
+				};
+
+				// when
+				await sendFormEmail(formResult, "contact@example.com");
+
+				// then
+				const emailArg = sendMailMock.mock.calls[0][0];
+				expect(emailArg.attachments).toHaveLength(1);
+				expect(emailArg.attachments[0]).toMatchObject({
+					filename: "document.pdf",
+					contentType: "application/pdf",
+					encoding: "base64",
+					content: "JVBERi0x",
+				});
+			});
+		});
+	});
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,5 +5,8 @@ export default getViteConfig({
 	test: {
 		globals: true,
 		include: ["tests/**/*.test.ts"],
+		restoreMocks: true,
+		unstubEnvs: true,
+		unstubGlobals: true,
 	},
 });


### PR DESCRIPTION
## 💥 Problème

Les tests unitaires existants (PR #12) couvraient uniquement les fonctions de formatage (`extractCustomFields`, `formatAttachment`). La fonction principale `createConversation` n'était pas testée, et la logique d'envoi mail était inlinée dans `src/actions/index.ts`, ce qui la rendait impossible à tester unitairement.

## 👩‍🚀 Proposition

- **Tests `createConversation`** : 3 cas dans `freescout.service.test.ts` — POST avec le corps correct, erreur API, mise à jour du client si les noms diffèrent.
- **Service mail** : extraction de la logique SMTP vers `src/services/mail.service.ts`. Seule `sendFormEmail` est exposée et testée — les sous-fonctions internes sont couvertes indirectement.


## ♻️ Pour tester

- Non Régression sur l'envoi de mail

```bash
npm run test:unit   # 14 tests, 4 fichiers — tous verts
npm run lint        # 1 warning pré-existant (quill.ts, hors scope)
