### PR TITLE
[TECH] Ajout de la license pour survey JS (PIX-22382)

### DIFF
--- a/src/pages/creator/[slug].astro
+++ b/src/pages/creator/[slug].astro
@@ -1,6 +1,5 @@
 ---
 const params = Astro.params;
-
 let _surveySchema = null;
 
 try {
@@ -30,6 +29,10 @@ function _isCurrentFormNewForm(formSlug: string) {
 		<meta name="generator" content={Astro.generator} />
 
 		<script>
+			import { slk } from "survey-core";
+
+			slk(import.meta.env.PUBLIC_SURVEYJS_LICENSE);
+
 			import { SurveyCreator } from "survey-creator-js";
 			import "survey-core";
 			import "survey-core/i18n/french";


### PR DESCRIPTION
## 💥 Problème
On a une license surveyJS, mais on ne l'utilise pas encore dans le code. Le bandeau d'utilisation free est affiché.

## 👩‍🚀 Proposition
En suivant la doc de surveyJS, on appelle leur méthode slk() avec la license en paramètre

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
On verra en recette 🙏 

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
