### PR TITLE
[BUGFIX] Ré-ordonner les imports de modules

### DIFF
--- a/src/pages/creator/[slug].astro
+++ b/src/pages/creator/[slug].astro
@@ -30,9 +30,6 @@ function _isCurrentFormNewForm(formSlug: string) {
 
 		<script>
 			import { slk } from "survey-core";
-
-			slk(import.meta.env.PUBLIC_SURVEYJS_LICENSE);
-
 			import { SurveyCreator } from "survey-creator-js";
 			import "survey-core";
 			import "survey-core/i18n/french";
@@ -49,6 +46,12 @@ function _isCurrentFormNewForm(formSlug: string) {
 				getLocaleStrings,
 				PropertyGridEditorCollection,
 			} from "survey-creator-core";
+
+			import { Serializer, SvgRegistry } from "survey-core";
+			import initQuill from "../../quill";
+
+			slk(import.meta.env.PUBLIC_SURVEYJS_LICENSE);
+
 			surveyLocalization.supportedLocales = ["en", "fr"];
 			surveyLocalization.defaultLocale = "fr";
 
@@ -60,9 +63,6 @@ function _isCurrentFormNewForm(formSlug: string) {
 
 			const creator = new SurveyCreator(creatorOptions);
 			creator.applyTheme(SharpLightPanelless);
-
-			import { Serializer, SvgRegistry } from "survey-core";
-			import initQuill from "../../quill";
 
 			// Add a property to the Survey class
 			Serializer.addProperty("survey", {


### PR DESCRIPTION
## 💥 Problème
J'ai tout cassé avec un appel de méthode entre deux imports de modules, et du coup on se retrouvais avec une erreur JS

## 👩‍🚀 Proposition
Mettre tous les imports de modules au début, et ensuite appeler les méthodes nécéssaires

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
Ça va marcher, trust me, i'm an engineer 

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
