### PR TITLE
[TECH] Ajout du secret lors du build de l'image docker pour surveyJS

### DIFF
--- a/.github/workflows/docker-main.yml
+++ b/.github/workflows/docker-main.yml
@@ -14,7 +14,8 @@ jobs:
           {
             "name": "pix-forms",
             "context": "./",
-            "dockerfile": "./Dockerfile"
+            "dockerfile": "./Dockerfile",
+            "build-args": ["PUBLIC_SURVEYJS_LICENSE=${{ secrets.PUBLIC_SURVEYJS_LICENSE }}"]
           }
         ]
     secrets:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -13,7 +13,8 @@ jobs:
           {
             "name": "pix-forms",
             "context": "./",
-            "dockerfile": "./Dockerfile"
+            "dockerfile": "./Dockerfile",
+            "build-args": ["PUBLIC_SURVEYJS_LICENSE=${{ secrets.PUBLIC_SURVEYJS_LICENSE }}"]
           }
         ]
     secrets:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN npm ci
 
 # Copier le reste et build
 COPY . .
+ARG PUBLIC_SURVEYJS_LICENSE
 RUN npm run build
 
 # # Configuration utilisateur non-root


### PR DESCRIPTION
## 💥 Problème
Actuellement la var d'env était injectée une fois le build fait via le cluster kube. Sauf qu'on en a besoin avant, lors du build sinon l'application build sans, et crash

## 👩‍🚀 Proposition
On ajoute la variable en secret GH afin qu'elle soit injectée lors du build de l'image docker

## 👁️ Remarques
On pourra supprimer le secret côté kube si cette méthode fonctionne

## ♻️ Pour tester
Cette fois promis ça marche

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
