### PR TITLE
[TECH] Changer le secret en variable pour la license SurveyJS

### DIFF
--- a/.github/workflows/docker-main.yml
+++ b/.github/workflows/docker-main.yml
@@ -15,7 +15,7 @@ jobs:
             "name": "pix-forms",
             "context": "./",
             "dockerfile": "./Dockerfile",
-            "build-args": ["PUBLIC_SURVEYJS_LICENSE=${{ secrets.PUBLIC_SURVEYJS_LICENSE }}"]
+            "build-args": ["PUBLIC_SURVEYJS_LICENSE=${{ vars.PUBLIC_SURVEYJS_LICENSE }}"]
           }
         ]
     secrets:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -14,7 +14,7 @@ jobs:
             "name": "pix-forms",
             "context": "./",
             "dockerfile": "./Dockerfile",
-            "build-args": ["PUBLIC_SURVEYJS_LICENSE=${{ secrets.PUBLIC_SURVEYJS_LICENSE }}"]
+            "build-args": ["PUBLIC_SURVEYJS_LICENSE=${{ vars.PUBLIC_SURVEYJS_LICENSE }}"]
           }
         ]
     secrets:


### PR DESCRIPTION
## 💥 Problème
Le problème : dans les appels à un workflow réutilisable, le contexte secrets n'est pas accessible dans le bloc with — seulement dans le bloc secrets.

Or PUBLIC_SURVEYJS_LICENSE finit de toute façon dans le bundle JS client (c'est une variable PUBLIC_), donc ce n'est pas vraiment un secret.

## 👩‍🚀 Proposition
Utiliser une variable de repo (vars) plutôt qu'un secret — le contexte vars est accessible dans with.

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
La c'est la bonne, c'est sur parce que je le dis

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
