### PR TITLE
[TECH] Revenir en arrière sur les travaux de la license SurveyJS

### DIFF
--- a/.github/workflows/docker-main.yml
+++ b/.github/workflows/docker-main.yml
@@ -14,8 +14,7 @@ jobs:
           {
             "name": "pix-forms",
             "context": "./",
-            "dockerfile": "./Dockerfile",
-            "build-args": ["PUBLIC_SURVEYJS_LICENSE=${{ vars.PUBLIC_SURVEYJS_LICENSE }}"]
+            "dockerfile": "./Dockerfile"
           }
         ]
     secrets:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -13,8 +13,7 @@ jobs:
           {
             "name": "pix-forms",
             "context": "./",
-            "dockerfile": "./Dockerfile",
-            "build-args": ["PUBLIC_SURVEYJS_LICENSE=${{ vars.PUBLIC_SURVEYJS_LICENSE }}"]
+            "dockerfile": "./Dockerfile"
           }
         ]
     secrets:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN npm ci
 
 # Copier le reste et build
 COPY . .
-ARG PUBLIC_SURVEYJS_LICENSE
 RUN npm run build
 
 # # Configuration utilisateur non-root

--- a/src/pages/creator/[slug].astro
+++ b/src/pages/creator/[slug].astro
@@ -1,5 +1,6 @@
 ---
 const params = Astro.params;
+
 let _surveySchema = null;
 
 try {
@@ -29,10 +30,6 @@ function _isCurrentFormNewForm(formSlug: string) {
 		<meta name="generator" content={Astro.generator} />
 
 		<script>
-			import { slk } from "survey-core";
-
-			slk(import.meta.env.PUBLIC_SURVEYJS_LICENSE);
-
 			import { SurveyCreator } from "survey-creator-js";
 			import "survey-core";
 			import "survey-core/i18n/french";

--- a/src/pages/creator/[slug].astro
+++ b/src/pages/creator/[slug].astro
@@ -30,6 +30,9 @@ function _isCurrentFormNewForm(formSlug: string) {
 
 		<script>
 			import { slk } from "survey-core";
+
+			slk(import.meta.env.PUBLIC_SURVEYJS_LICENSE);
+
 			import { SurveyCreator } from "survey-creator-js";
 			import "survey-core";
 			import "survey-core/i18n/french";
@@ -46,12 +49,6 @@ function _isCurrentFormNewForm(formSlug: string) {
 				getLocaleStrings,
 				PropertyGridEditorCollection,
 			} from "survey-creator-core";
-
-			import { Serializer, SvgRegistry } from "survey-core";
-			import initQuill from "../../quill";
-
-			slk(import.meta.env.PUBLIC_SURVEYJS_LICENSE);
-
 			surveyLocalization.supportedLocales = ["en", "fr"];
 			surveyLocalization.defaultLocale = "fr";
 
@@ -63,6 +60,9 @@ function _isCurrentFormNewForm(formSlug: string) {
 
 			const creator = new SurveyCreator(creatorOptions);
 			creator.applyTheme(SharpLightPanelless);
+
+			import { Serializer, SvgRegistry } from "survey-core";
+			import initQuill from "../../quill";
 
 			// Add a property to the Survey class
 			Serializer.addProperty("survey", {


### PR DESCRIPTION
## 💥 Problème
Les précédentes PR n'ont pas été concluantes pour mettre en place la license sur SurveyJS. La recette est cassée, et on ne trouve pas de fix pour l'instant.

## 👩‍🚀 Proposition
On décide de revenir en arrière pour le moment afin de revenir dans un état stable, le temps de se poser et de réfléchir à une solution fonctionnelle

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
😢 

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
