### PR TITLE
[TECH] Ne plus afficher les balises html à l'affichage des forms (PIX-22850)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@friendlycaptcha/sdk": "^0.1.26",
 				"@friendlycaptcha/server-sdk": "^0.1.2",
 				"astro": "^6.1.5",
+				"dompurify": "^3.4.5",
 				"dotenv": "^17.2.0",
 				"nodemailer": "^8.0.5",
 				"quill": "^2.0.3",
@@ -20,6 +21,7 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.1.2",
+				"@types/dompurify": "^3.2.0",
 				"@types/nodemailer": "^6.4.17",
 				"playwright": "^1.54.1",
 				"prettier": "^3.6.2",
@@ -1754,6 +1756,17 @@
 			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
 			"license": "MIT"
 		},
+		"node_modules/@types/dompurify": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
+			"integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
+			"deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dompurify": "*"
+			}
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1832,6 +1845,13 @@
 			"peerDependencies": {
 				"@types/react": "^19.0.0"
 			}
+		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/@types/unist": {
 			"version": "3.0.3",
@@ -2513,6 +2533,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/dompurify": {
+			"version": "3.4.5",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+			"integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
 			}
 		},
 		"node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"@friendlycaptcha/sdk": "^0.1.26",
 		"@friendlycaptcha/server-sdk": "^0.1.2",
 		"astro": "^6.1.5",
+		"dompurify": "^3.4.5",
 		"dotenv": "^17.2.0",
 		"nodemailer": "^8.0.5",
 		"quill": "^2.0.3",
@@ -25,6 +26,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.1.2",
+		"@types/dompurify": "^3.2.0",
 		"@types/nodemailer": "^6.4.17",
 		"playwright": "^1.54.1",
 		"prettier": "^3.6.2",

--- a/src/pages/form/[slug].astro
+++ b/src/pages/form/[slug].astro
@@ -56,6 +56,7 @@ const pageTitle = form.title;
 		const sdk = new FriendlyCaptchaSDK();
 
 		import { actions } from "astro:actions";
+		import DOMPurify from "dompurify";
 
 		const surveyJson = JSON.parse(
 			document.getElementById("form-data").getAttribute("data-survey"),
@@ -64,6 +65,9 @@ const pageTitle = form.title;
 		const surveyInstance = new SurveyModel(surveyJson);
 		surveyInstance.applyTheme(SharpLightPanelless);
 		surveyInstance.locale = surveyJson?.locale || "fr";
+		surveyInstance.onTextMarkdown.add((_survey, options) => {
+			options.html = DOMPurify.sanitize(options.text);
+		});
 
 		function renderForm(captchaResponse: string) {
 			surveyInstance.render(document.getElementById("surveyContainer"));

--- a/src/quill.ts
+++ b/src/quill.ts
@@ -42,7 +42,7 @@ export default function initQuill(
 			let isValueChanging = false;
 			editor.on("text-change", () => {
 				isValueChanging = true;
-				question.value = editor.root.innerHTML;
+				question.value = _stripWrappingParagraph(editor.root.innerHTML);
 				isValueChanging = false;
 			});
 			const updateValueHandler = () => {
@@ -63,20 +63,9 @@ export default function initQuill(
 
 	CustomWidgetCollection.Instance.addCustomWidget(widget, "customtype");
 
-	function applyHtml(_: SurveyModel, options: TextMarkdownEvent) {
-		let str = options.text;
-		if (str.indexOf("<p>") === 0) {
-			// Remove root paragraphs <p></p>
-			str = str.substring(3);
-			str = str.substring(0, str.length - 4);
-		}
-		// Set HTML markup to render
-		options.html = str;
-	}
-
-	creator.survey.onTextMarkdown.add(applyHtml);
+	creator.survey.onTextMarkdown.add(_applyHtml);
 	creator.onSurveyInstanceCreated.add((_, options) => {
-		options.survey.onTextMarkdown.add(applyHtml);
+		options.survey.onTextMarkdown.add(_applyHtml);
 	});
 
 	// Register `quill` as an editor for properties of the `text` and `html` types in the Survey Creator's Property Grid
@@ -84,4 +73,15 @@ export default function initQuill(
 		fit: (prop) => prop.type === "text" || prop.type === "html",
 		getJSON: () => ({ type: "quill" }),
 	});
+}
+
+function _applyHtml(_: SurveyModel, options: TextMarkdownEvent) {
+	options.html = _stripWrappingParagraph(options.text);
+}
+
+function _stripWrappingParagraph(html: string): string {
+	if (html.indexOf("<p>") === 0) {
+		return html.substring(3, html.length - 4);
+	}
+	return html;
 }


### PR DESCRIPTION
## 💥 Problème

L'éditeur Quill (utilisé dans le Creator pour les titres de questions) enveloppe
systématiquement son contenu dans un `<p>`. Ces balises étaient persistées dans le JSON,
ce qui causait un rendu cassé côté formulaire : l'astérisque obligatoire `*` apparaissait
sur une ligne séparée du label.

## 👩‍🚀 Proposition

- **Affichage du formulaire** (`[slug].astro`) : ajout de DOMPurify sur l'événement
  `onTextMarkdown` de SurveyJS — le HTML est assaini avant rendu.
- **Creator** (`quill.ts`) : le `<p>` englobant est strippé à la sauvegarde, donc les
  nouveaux formulaires n'ont plus de balises parasites dans leurs JSON.

## ♻️ Pour tester
 Ouvrir le Creator, éditer un titre de question via Quill, verifier dans l'éditeur json
   → vérifier que le JSON ne contient pas de `<p>` autour du titre.

